### PR TITLE
Switch report scripts to SmtpClient email API

### DIFF
--- a/powershell/E8-ML1-PA-01.ps1
+++ b/powershell/E8-ML1-PA-01.ps1
@@ -44,4 +44,13 @@ $stamp = Get-Date -Format 'yyyy-MM-dd'
 $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
 
 $subject = "E8-ML1-PA-01 and ML1-PO-01 Onboarding Devices Report - $stamp @@@"
-Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+$mail = New-Object System.Net.Mail.MailMessage
+$mail.From = $mailFrom
+$mailTo | ForEach-Object { $mail.To.Add($_) }
+$mail.Subject = $subject
+$mail.Body = $bodyHtml
+$mail.IsBodyHtml = $true
+
+$smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+$smtpClient.Send($mail)

--- a/powershell/E8-ML1-PA-04-Browsers.ps1
+++ b/powershell/E8-ML1-PA-04-Browsers.ps1
@@ -41,4 +41,13 @@ $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--S
 
 # Send the report
 $subject = "E8-ML1-PA-04 Browser Vulnerability Report - $stamp @@@"
-Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+$mail = New-Object System.Net.Mail.MailMessage
+$mail.From = $mailFrom
+$mailTo | ForEach-Object { $mail.To.Add($_) }
+$mail.Subject = $subject
+$mail.Body = $bodyHtml
+$mail.IsBodyHtml = $true
+
+$smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+$smtpClient.Send($mail)

--- a/powershell/E8-ML1-PA-04-EndpointSecurity.ps1
+++ b/powershell/E8-ML1-PA-04-EndpointSecurity.ps1
@@ -48,5 +48,14 @@ $stamp    = (Get-Date).ToString('yyyy-MM-dd')
 $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
 
 $subject = "E8-ML1-PA-04 EndpointSecurity Vuln Report - $stamp @@@"
-Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+$mail = New-Object System.Net.Mail.MailMessage
+$mail.From = $mailFrom
+$mailTo | ForEach-Object { $mail.To.Add($_) }
+$mail.Subject = $subject
+$mail.Body = $bodyHtml
+$mail.IsBodyHtml = $true
+
+$smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+$smtpClient.Send($mail)
 

--- a/powershell/E8-ML1-PA-04-Office.ps1
+++ b/powershell/E8-ML1-PA-04-Office.ps1
@@ -50,4 +50,13 @@ $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable `
 
 # Send the report
 $subject = "E8-ML1-PA-04 Office Vulnerabilities Report - $stamp @@@"
-Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+$mail = New-Object System.Net.Mail.MailMessage
+$mail.From = $mailFrom
+$mailTo | ForEach-Object { $mail.To.Add($_) }
+$mail.Subject = $subject
+$mail.Body = $bodyHtml
+$mail.IsBodyHtml = $true
+
+$smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+$smtpClient.Send($mail)

--- a/powershell/E8-ML1-PA-04-PDF.ps1
+++ b/powershell/E8-ML1-PA-04-PDF.ps1
@@ -36,4 +36,13 @@ $stamp    = (Get-Date).ToString('yyyy-MM-dd')
 $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
 
 $subject = "E8-ML1-PA-04 PDF (Acrobat/Reader) Vulnerability Report - $stamp @@@"
-Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+$mail = New-Object System.Net.Mail.MailMessage
+$mail.From = $mailFrom
+$mailTo | ForEach-Object { $mail.To.Add($_) }
+$mail.Subject = $subject
+$mail.Body = $bodyHtml
+$mail.IsBodyHtml = $true
+
+$smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+$smtpClient.Send($mail)

--- a/powershell/E8-ML1-PA-05.ps1
+++ b/powershell/E8-ML1-PA-05.ps1
@@ -43,7 +43,17 @@ if ($result.Results.Count -gt 0) {
     # send email only when there are results (your change was correct)
     $stamp   = (Get-Date).ToString('yyyy-MM-dd')
     $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
-    Send-MailMessage -To $mailTo -From $mailFrom -Subject "E8-ML1-PA-05 Internet-facing Critical/Exploited Vulns older than 48h - $stamp @@@" -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+    $subject = "E8-ML1-PA-05 Internet-facing Critical/Exploited Vulns older than 48h - $stamp @@@"
+
+    $mail = New-Object System.Net.Mail.MailMessage
+    $mail.From = $mailFrom
+    $mailTo | ForEach-Object { $mail.To.Add($_) }
+    $mail.Subject = $subject
+    $mail.Body = $bodyHtml
+    $mail.IsBodyHtml = $true
+
+    $smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+    $smtpClient.Send($mail)
 }
 else {
     Throw 'No findings. Email not sent.'

--- a/powershell/E8-ML1-PA-06.ps1
+++ b/powershell/E8-ML1-PA-06.ps1
@@ -39,4 +39,13 @@ $stamp = Get-Date -Format 'yyyy-MM-dd'
 $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
 
 $subject = "E8-ML1-PA-06 Internet facing vulnerability > 14d - $stamp @@@"
-Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+$mail = New-Object System.Net.Mail.MailMessage
+$mail.From = $mailFrom
+$mailTo | ForEach-Object { $mail.To.Add($_) }
+$mail.Subject = $subject
+$mail.Body = $bodyHtml
+$mail.IsBodyHtml = $true
+
+$smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+$smtpClient.Send($mail)

--- a/powershell/E8-ML1-PA-07-Browsers.ps1
+++ b/powershell/E8-ML1-PA-07-Browsers.ps1
@@ -44,7 +44,16 @@ if ($result.Results.Count) {
 
     # Send the report
     $subject = "E8-ML1-PA-07 Browser Vulnerabilities older than 14d - $stamp @@@"
-    Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+    $mail = New-Object System.Net.Mail.MailMessage
+    $mail.From = $mailFrom
+    $mailTo | ForEach-Object { $mail.To.Add($_) }
+    $mail.Subject = $subject
+    $mail.Body = $bodyHtml
+    $mail.IsBodyHtml = $true
+
+    $smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+    $smtpClient.Send($mail)
 }
 else {
     throw "No devices with Browser vulnerabilities found."

--- a/powershell/E8-ML1-PA-07-EndpointSecurity.ps1
+++ b/powershell/E8-ML1-PA-07-EndpointSecurity.ps1
@@ -39,7 +39,16 @@ if ($result.Results.Count) {
     $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
 
     $subject = "E8-ML1-PA-07 Endpoint Security updates older than 14d - $stamp @@@"
-    Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+    $mail = New-Object System.Net.Mail.MailMessage
+    $mail.From = $mailFrom
+    $mailTo | ForEach-Object { $mail.To.Add($_) }
+    $mail.Subject = $subject
+    $mail.Body = $bodyHtml
+    $mail.IsBodyHtml = $true
+
+    $smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+    $smtpClient.Send($mail)
 }
 else {
     throw "No devices with Endpoint Security issues found. GOOD BOY!"

--- a/powershell/E8-ML1-PA-07-Office.ps1
+++ b/powershell/E8-ML1-PA-07-Office.ps1
@@ -43,7 +43,16 @@ if ($result.Results.Count) {
 
     # Send the report
     $subject = "E8-ML1-PA-07 Office Vulnerabilities older than 14d - $stamp @@@"
-    Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+    $mail = New-Object System.Net.Mail.MailMessage
+    $mail.From = $mailFrom
+    $mailTo | ForEach-Object { $mail.To.Add($_) }
+    $mail.Subject = $subject
+    $mail.Body = $bodyHtml
+    $mail.IsBodyHtml = $true
+
+    $smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+    $smtpClient.Send($mail)
 }
 else {
     throw "No devices with Office vulnerabilities found."

--- a/powershell/E8-ML1-PA-07-PDF.ps1
+++ b/powershell/E8-ML1-PA-07-PDF.ps1
@@ -31,7 +31,16 @@ if ($result.Results.Count) {
     $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
 
     $subject = "E8-ML1-PA-07 PDF (Acrobat/Reader) Vulnerabilities older than 14d - $stamp @@@"
-    Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+
+    $mail = New-Object System.Net.Mail.MailMessage
+    $mail.From = $mailFrom
+    $mailTo | ForEach-Object { $mail.To.Add($_) }
+    $mail.Subject = $subject
+    $mail.Body = $bodyHtml
+    $mail.IsBodyHtml = $true
+
+    $smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+    $smtpClient.Send($mail)
 } else {
     throw "No devices with Acrobat/Reader vulnerabilities found."
 }

--- a/powershell/E8-ML1-PA-08.ps1
+++ b/powershell/E8-ML1-PA-08.ps1
@@ -37,7 +37,17 @@ if ($result.Results.Count -gt 0) {
     # send email only when there are results (your change was correct)
     $stamp   = (Get-Date).ToString('yyyy-MM-dd')
     $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
-    Send-MailMessage -To $mailTo -From $mailFrom -Subject "E8-ML1-PA-08 Internet-facing EOS applications - $stamp @@@" -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+    $subject = "E8-ML1-PA-08 Internet-facing EOS applications - $stamp @@@"
+
+    $mail = New-Object System.Net.Mail.MailMessage
+    $mail.From = $mailFrom
+    $mailTo | ForEach-Object { $mail.To.Add($_) }
+    $mail.Subject = $subject
+    $mail.Body = $bodyHtml
+    $mail.IsBodyHtml = $true
+
+    $smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+    $smtpClient.Send($mail)
 }
 else {
     Throw 'No findings. Email not sent.'

--- a/powershell/E8-ML1-PA-09.ps1
+++ b/powershell/E8-ML1-PA-09.ps1
@@ -37,7 +37,17 @@ if ($result.Results.Count -gt 0) {
     # send email only when there are results (your change was correct)
     $stamp   = (Get-Date).ToString('yyyy-MM-dd')
     $bodyHtml = $template -replace '<!--REPORT_TABLE-->', $htmlTable -replace '<!--STAMP-->', $stamp
-    Send-MailMessage -To $mailTo -From $mailFrom -Subject "E8-ML1-PA-09 End Of Support (EOS) applications - $stamp @@@" -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+    $subject = "E8-ML1-PA-09 End Of Support (EOS) applications - $stamp @@@"
+
+    $mail = New-Object System.Net.Mail.MailMessage
+    $mail.From = $mailFrom
+    $mailTo | ForEach-Object { $mail.To.Add($_) }
+    $mail.Subject = $subject
+    $mail.Body = $bodyHtml
+    $mail.IsBodyHtml = $true
+
+    $smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+    $smtpClient.Send($mail)
 }
 else {
     Throw 'No findings. Email not sent.'

--- a/powershell/E8-ML1-PO-06.ps1
+++ b/powershell/E8-ML1-PO-06.ps1
@@ -49,4 +49,12 @@ $bodyHtml = $template -replace '<!--REPORT_TABLE-->',$htmlTable -replace '<!--ST
 
 $subject = "E8-ML1-PO-06 Patch Operating Systems - $stamp @@@"
 
-Send-MailMessage -To $mailTo -From $mailFrom -Subject $subject -Body $bodyHtml -BodyAsHtml -SmtpServer $smtp
+$mail = New-Object System.Net.Mail.MailMessage
+$mail.From = $mailFrom
+$mailTo | ForEach-Object { $mail.To.Add($_) }
+$mail.Subject = $subject
+$mail.Body = $bodyHtml
+$mail.IsBodyHtml = $true
+
+$smtpClient = New-Object System.Net.Mail.SmtpClient($smtp)
+$smtpClient.Send($mail)


### PR DESCRIPTION
## Summary
- replace deprecated `Send-MailMessage` with `System.Net.Mail.SmtpClient`
- build `MailMessage` objects for each report prior to sending

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `dpkg -i powershell_7.4.3-1.deb_amd64.deb` *(fails: dependency problems prevent configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68944d9e67c483268495028f51884a88