### PR TITLE
feat: add Graph auth header and mail sender

### DIFF
--- a/powershell/E8-Common.psm1
+++ b/powershell/E8-Common.psm1
@@ -2,6 +2,7 @@
   Common helpers shared by all PA scripts.
   - Get-E8Paths      : resolve base/kql/message dirs from a script under E8\powershell
   - Invoke-E8Query   : call Defender Advanced Hunting with readable error output
+  - Send-E8ExchangeOnlineMail : send HTML email via Microsoft Graph
 #>
 
 function Get-E8Paths {
@@ -41,4 +42,39 @@ function Invoke-E8Query {
     }
 }
 
-Export-ModuleMember -Function Get-E8Paths, Invoke-E8Query
+function Send-E8ExchangeOnlineMail {
+    <#
+      .SYNOPSIS  Send an HTML email using Microsoft Graph.
+      .PARAMETER TenantId   Entra ID tenant GUID.
+      .PARAMETER ClientId   App registration ID.
+      .PARAMETER From       Sender email address.
+      .PARAMETER To         Recipient email addresses.
+      .PARAMETER Subject    Email subject.
+      .PARAMETER BodyHtml   HTML body content.
+      .PARAMETER SecretPath Path to DPAPI-protected secret blob.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$TenantId,
+        [Parameter(Mandatory)][string]$ClientId,
+        [Parameter(Mandatory)][string]$From,
+        [Parameter(Mandatory)][string[]]$To,
+        [Parameter(Mandatory)][string]$Subject,
+        [Parameter(Mandatory)][string]$BodyHtml,
+        [string]$SecretPath = 'C:\\SECRET\\defender.secret'
+    )
+
+    $headers = Get-E8GraphAuthHeader -TenantId $TenantId -ClientId $ClientId -SecretPath $SecretPath
+    $uri     = "https://graph.microsoft.com/v1.0/users/$From/sendMail"
+
+    $payload = @{ 
+        Message = @{ 
+            Subject = $Subject
+            Body    = @{ ContentType = 'HTML'; Content = $BodyHtml }
+            ToRecipients = $To | ForEach-Object { @{ EmailAddress = @{ Address = $_ } } }
+        }
+    } | ConvertTo-Json -Depth 4
+
+    Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $payload
+}
+
+Export-ModuleMember -Function Get-E8Paths, Invoke-E8Query, Send-E8ExchangeOnlineMail


### PR DESCRIPTION
## Summary
- add Get-E8GraphAuthHeader for Microsoft Graph auth
- send Exchange Online mail via new helper using Microsoft Graph

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./powershell/E8-Defender_auth.psm1; Import-Module ./powershell/E8-Common.psm1; Get-Command Get-E8GraphAuthHeader; Get-Command Send-E8ExchangeOnlineMail"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_b_68be6f9da3b083269184437eb262ff87