### PR TITLE
Document Graph email configuration

### DIFF
--- a/powershell/E8-config.ps1
+++ b/powershell/E8-config.ps1
@@ -10,7 +10,13 @@ $secretPath = 'C:\SECRET\defender.secret'
 # Defender API root (rarely changes)
 $apiBase = 'https://api.securitycenter.microsoft.com'
 
-# Mail settings for reports
-$smtp         = 'mail.contoso.com'
-$mailFrom     = 'sender@contoso.com'
-$mailTo       = @('servicedesk@contoso.com')
+# Mail settings for reports via Microsoft Graph
+# Requires the app to have the Mail.Send application permission
+$mailFrom = 'sender@contoso.com'
+$mailTo   = @('servicedesk@contoso.com')
+
+# Optional: distinct credentials for the Microsoft Graph app
+# Uncomment and set if the Graph app differs from the Defender app
+#$graphTenantId  = '...'
+#$graphClientId  = '...'
+#$graphSecretPath = 'C:\SECRET\graph.secret'

--- a/powershell/readme.md
+++ b/powershell/readme.md
@@ -1,1 +1,24 @@
+# PowerShell scripts
 
+## Grant required permissions
+1. Register an application in Microsoft Entra ID.
+2. Under **API permissions**, add application permissions and grant admin consent for:
+   - **Microsoft Graph** → `Mail.Send`
+   - **Microsoft Threat Protection** → `AdvancedHunting.Read.All`
+3. Create a client secret for each app.
+
+## Configure `E8-config.ps1`
+1. Update tenant ID, client ID, and secret path for the Defender app:
+   - `$tenantId`
+   - `$clientId`
+   - `$secretPath`
+2. Set mail sender and recipients:
+   - `$mailFrom`
+   - `$mailTo`
+3. If a separate Graph app is used, also configure:
+   - `$graphTenantId`
+   - `$graphClientId`
+   - `$graphSecretPath`
+4. Run `E8-StoreSecret.ps1` once for each secret path to encrypt the client secret.
+
+After configuration, execute the desired report scripts from this directory.


### PR DESCRIPTION
## Summary
- remove obsolete SMTP configuration and note Graph Mail.Send requirement
- add optional variables for separate Microsoft Graph credentials
- document permission grant and config steps in PowerShell README

## Testing
- `pwsh -NoLogo -NonInteractive -Command ". ./powershell/E8-config.ps1; 'loaded'"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_b_68be7e3be18083269770af79b865a3bb