### PR TITLE
Qualify ProtectedData type in auth module

### DIFF
--- a/powershell/E8-Defender_auth.psm1
+++ b/powershell/E8-Defender_auth.psm1
@@ -5,6 +5,8 @@
     Get-E8GraphAuthHeader - returns a bearer-token header for Microsoft Graph.
 #>
 
+Add-Type -AssemblyName System.Security
+
 function Get-E8ClientSecret {
     <#
       .SYNOPSIS  Decrypt the DPAPI-protected secret.
@@ -19,7 +21,7 @@ function Get-E8ClientSecret {
     }
 
     $enc  = [IO.File]::ReadAllBytes($Path)
-    $plainBytes = [Security.Cryptography.ProtectedData]::Unprotect($enc, $null, 'LocalMachine')
+    $plainBytes = [System.Security.Cryptography.ProtectedData]::Unprotect($enc, $null, 'LocalMachine')
     [Text.Encoding]::UTF8.GetString($plainBytes)
 }
 


### PR DESCRIPTION
## Summary
- ensure ProtectedData type fully qualified for secret decryption
- load System.Security assembly for access to ProtectedData

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./powershell/E8-Defender_auth.psm1; 'module imported'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c3daf0e24c8326b570f4a1f324c934