### PR TITLE
Store secret in registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ Scripts and templates for generating Essential Eight (E8) compliance reports usi
 ## Repository structure
 
 - **powershell/** – PowerShell modules and report scripts.
-  - `E8-config.ps1` – Defines tenant, client, secret path, API base, and mail settings
+  - `E8-config.ps1` – Defines tenant, client, API base, and mail settings
   - `E8-Common.psm1` – Utilities for resolving paths and running Defender Advanced Hunting queries
-  - `E8-Defender_auth.psm1` – Decrypts the DPAPI-protected secret and builds bearer-token headers for Defender APIs
-  - `E8-StoreSecret.ps1` – One‑time helper to encrypt and store the Defender app client secret via DPAPI
+  - `E8-Defender_auth.psm1` – Decrypts the DPAPI-protected secret from the HKCU registry and builds bearer-token headers for Defender APIs
+  - `E8-StoreSecret.ps1` – One‑time helper to encrypt and store the Defender app client secret in the user's HKCU registry hive via DPAPI
   - `E8-ML1-PA-01.ps1` (and similar scripts) – Load a KQL query and HTML template, run the query, and email a formatted report via Microsoft Graph
-- **kql/** – Kusto Query Language files used by the report scripts.  
+- **kql/** – Kusto Query Language files used by the report scripts.
   Example: `E8-ML1-PA-01_query.kql` lists devices that can be onboarded and their IP addresses
 - **message/** – HTML templates for report emails, containing instructions, report placeholders, and ticketing metadata
 
 ## Setup
 
 1. [Prepare Microsoft Entra ID and Defender](#entra-and-defender-setup) by registering an app with the required API permissions.
-2. Customize `powershell/E8-config.ps1` with your tenant ID, client ID, secret path, API base, and mail settings.
-3. Run `powershell/E8-StoreSecret.ps1` once to encrypt and store the Defender app client secret using DPAPI.
+2. Customize `powershell/E8-config.ps1` with your tenant ID, client ID, API base, and mail settings.
+3. Run `powershell/E8-StoreSecret.ps1` once to encrypt and store the Defender app client secret in the current user's `HKCU\Software\E8` registry key using DPAPI.
 4. Confirm the host has network access to the Defender APIs and Microsoft Graph.
 
 ## Entra and Defender setup
@@ -29,7 +29,7 @@ Scripts and templates for generating Essential Eight (E8) compliance reports usi
    - **Microsoft Threat Protection** → `AdvancedHunting.Read.All`
 3. Create a client secret and record the secret value, client ID, and tenant ID.
 4. Ensure the organization has Microsoft Defender enabled and licensed for Advanced Hunting queries.
-5. Run `powershell/E8-StoreSecret.ps1` to encrypt the client secret at the path referenced in `E8-config.ps1`.
+5. Run `powershell/E8-StoreSecret.ps1` to encrypt the client secret into the user's `HKCU\Software\E8` registry location.
 
 ## Usage
 
@@ -40,4 +40,3 @@ Scripts and templates for generating Essential Eight (E8) compliance reports usi
 ## License
 
 Distributed under the GNU General Public License v3.0
-

--- a/powershell/E8-Common.psm1
+++ b/powershell/E8-Common.psm1
@@ -1,4 +1,4 @@
-﻿<#
+<#
   Common helpers shared by all PA scripts.
   - Get-E8Paths      : resolve base/kql/message dirs from a script under E8\powershell
   - Invoke-E8Query   : call Defender Advanced Hunting with readable error output
@@ -51,7 +51,6 @@ function Send-E8ExchangeOnlineMail {
       .PARAMETER To         Recipient email addresses.
       .PARAMETER Subject    Email subject.
       .PARAMETER BodyHtml   HTML body content.
-      .PARAMETER SecretPath Path to DPAPI-protected secret blob.
     #>
     param(
         [Parameter(Mandatory)][string]$TenantId,
@@ -59,15 +58,14 @@ function Send-E8ExchangeOnlineMail {
         [Parameter(Mandatory)][string]$From,
         [Parameter(Mandatory)][string[]]$To,
         [Parameter(Mandatory)][string]$Subject,
-        [Parameter(Mandatory)][string]$BodyHtml,
-        [string]$SecretPath = 'C:\SECRET\defender.secret'
+        [Parameter(Mandatory)][string]$BodyHtml
     )
 
-    $headers = Get-E8GraphAuthHeader -TenantId $TenantId -ClientId $ClientId -SecretPath $SecretPath
+    $headers = Get-E8GraphAuthHeader -TenantId $TenantId -ClientId $ClientId
     $uri     = "https://graph.microsoft.com/v1.0/users/$From/sendMail"
 
-    $payload = @{ 
-        Message = @{ 
+    $payload = @{
+        Message = @{
             Subject = $Subject
             Body    = @{ ContentType = 'HTML'; Content = $BodyHtml }
             ToRecipients = $To | ForEach-Object { @{ EmailAddress = @{ Address = $_ } } }

--- a/powershell/E8-ML1-PA-01.ps1
+++ b/powershell/E8-ML1-PA-01.ps1
@@ -14,7 +14,7 @@ if (-not (Test-Path $kqlPath))     { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)){ throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # KQL (strip comments + flatten)
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-04-Browsers.ps1
+++ b/powershell/E8-ML1-PA-04-Browsers.ps1
@@ -13,7 +13,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-04-EndpointSecurity.ps1
+++ b/powershell/E8-ML1-PA-04-EndpointSecurity.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-04-Office.ps1
+++ b/powershell/E8-ML1-PA-04-Office.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-04-PDF.ps1
+++ b/powershell/E8-ML1-PA-04-PDF.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-05.ps1
+++ b/powershell/E8-ML1-PA-05.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-06.ps1
+++ b/powershell/E8-ML1-PA-06.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-07-Browsers.ps1
+++ b/powershell/E8-ML1-PA-07-Browsers.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-07-EndpointSecurity.ps1
+++ b/powershell/E8-ML1-PA-07-EndpointSecurity.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-07-Office.ps1
+++ b/powershell/E8-ML1-PA-07-Office.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-07-PDF.ps1
+++ b/powershell/E8-ML1-PA-07-PDF.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-08.ps1
+++ b/powershell/E8-ML1-PA-08.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PA-09.ps1
+++ b/powershell/E8-ML1-PA-09.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-ML1-PO-06.ps1
+++ b/powershell/E8-ML1-PO-06.ps1
@@ -12,7 +12,7 @@ if (-not (Test-Path $kqlPath)) { throw "Query file not found: $kqlPath" }
 if (-not (Test-Path $templatePath)) { throw "Template file not found: $templatePath" }
 
 # Auth
-$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -SecretPath $secretPath -ApiBase $apiBase
+$headers = Get-MDATPAuthHeader -TenantId $tenantId -ClientId $clientId -ApiBase $apiBase
 
 # Load/flatten KQL
 $query = Get-Content -Raw -Path $kqlPath

--- a/powershell/E8-StoreSecret.ps1
+++ b/powershell/E8-StoreSecret.ps1
@@ -1,10 +1,11 @@
 <#
   One-time setup: run on the target server.
   Prompts for the Entra ID app client secret and stores it encrypted
-  with DPAPI (LocalMachine scope) at C:\SECRET\defender.secret.
+  with DPAPI (LocalMachine scope) under HKCU:\Software\E8.
 #>
 
-$secretPath = 'C:\SECRET\defender.secret'
+$regPath   = 'HKCU:\Software\E8'
+$valueName = 'ClientSecret'
 
 # Try to load the ProtectedData type (works across PS 5.1 and PS 7)
 try {
@@ -18,8 +19,8 @@ try {
     }
 }
 
-# Create folder
-$null = New-Item -ItemType Directory -Path (Split-Path -Path $secretPath) -Force
+# Create registry key
+$null = New-Item -Path $regPath -Force
 
 # Prompt
 $secure = Read-Host -Prompt 'Enter Defender Client Secret' -AsSecureString
@@ -43,7 +44,7 @@ $encrypted = [System.Security.Cryptography.ProtectedData]::Protect(
     [System.Security.Cryptography.DataProtectionScope]::LocalMachine
 )
 
-# Write to disk
-[IO.File]::WriteAllBytes($secretPath, $encrypted)
+# Write to registry
+Set-ItemProperty -Path $regPath -Name $valueName -Value $encrypted
 
-Write-Host "Encrypted secret written to $secretPath"
+Write-Host "Encrypted secret written to $regPath\$valueName"

--- a/powershell/E8-config.ps1
+++ b/powershell/E8-config.ps1
@@ -4,9 +4,6 @@
 $tenantId     = '...'
 $clientId     = '...'
 
-# Path to the DPAPI-protected secret created by E8-StoreSecret.ps1
-$secretPath = 'C:\SECRET\defender.secret'
-
 # Defender API root (rarely changes)
 $apiBase = 'https://api.securitycenter.microsoft.com'
 
@@ -19,4 +16,3 @@ $mailTo   = @('servicedesk@contoso.com')
 # Uncomment and set if the Graph app differs from the Defender app
 #$graphTenantId  = '...'
 #$graphClientId  = '...'
-#$graphSecretPath = 'C:\SECRET\graph.secret'

--- a/powershell/readme.md
+++ b/powershell/readme.md
@@ -8,17 +8,15 @@
 3. Create a client secret for each app.
 
 ## Configure `E8-config.ps1`
-1. Update tenant ID, client ID, and secret path for the Defender app:
+1. Update tenant ID and client ID for the Defender app:
    - `$tenantId`
    - `$clientId`
-   - `$secretPath`
 2. Set mail sender and recipients:
    - `$mailFrom`
    - `$mailTo`
 3. If a separate Graph app is used, also configure:
    - `$graphTenantId`
    - `$graphClientId`
-   - `$graphSecretPath`
-4. Run `E8-StoreSecret.ps1` once for each secret path to encrypt the client secret.
+4. Run `E8-StoreSecret.ps1` once to encrypt the client secret in the current user's `HKCU\Software\E8` registry key.
 
 After configuration, execute the desired report scripts from this directory.


### PR DESCRIPTION
## Summary
- store DPAPI-encrypted client secret under `HKCU:\Software\E8` instead of a file
- read secret from registry in auth module and remove `SecretPath` parameters across scripts
- refresh configuration and documentation to describe registry-based secret storage

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_b_68c7c1eced4c8326bd8dac2c134d0304